### PR TITLE
Add edge-to-edge support

### DIFF
--- a/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
@@ -1,0 +1,19 @@
+package nandorojo.modules.galeria
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.core.view.WindowCompat
+import com.github.iielse.imageviewer.ImageViewerDialogFragment
+
+class EdgeToEdgeImageViewerDialogFragment : ImageViewerDialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return Dialog(requireActivity(), R.style.Theme_FullScreenDialog).apply {
+            setCanceledOnTouchOutside(true)
+
+            window?.let {
+                WindowCompat.setDecorFitsSystemWindows(it, false)
+            }
+        }
+    }
+}

--- a/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
@@ -3,9 +3,11 @@ package nandorojo.modules.galeria
 import android.app.Dialog
 import android.os.Bundle
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.github.iielse.imageviewer.ImageViewerDialogFragment
 
-class EdgeToEdgeImageViewerDialogFragment : ImageViewerDialogFragment() {
+class EdgeToEdgeImageViewerDialogFragment(private val isAppearanceLightSystemBars: Boolean) :
+    ImageViewerDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return Dialog(requireActivity(), R.style.Theme_FullScreenDialog).apply {
@@ -13,6 +15,11 @@ class EdgeToEdgeImageViewerDialogFragment : ImageViewerDialogFragment() {
 
             window?.let {
                 WindowCompat.setDecorFitsSystemWindows(it, false)
+
+                WindowInsetsControllerCompat(it, it.decorView).run {
+                    isAppearanceLightStatusBars = isAppearanceLightSystemBars
+                    isAppearanceLightNavigationBars = isAppearanceLightSystemBars
+                }
             }
         }
     }

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
@@ -29,6 +29,9 @@ class GaleriaModule : Module() {
             Prop("disableHiddenOriginalImage") { view: GaleriaView, disableHiddenOriginalImage: Boolean ->
                 view.disableHiddenOriginalImage = disableHiddenOriginalImage
             }
+            Prop("edgeToEdge") { view: GaleriaView, edgeToEdge: Boolean ->
+                view.edgeToEdge = edgeToEdge
+            }
             Prop("transitionOffsetY") { view: GaleriaView, transitionOffsetY: Int? ->
                 view.transitionOffsetY = transitionOffsetY
             }

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -111,7 +111,9 @@ class GaleriaView(context: Context) : ViewGroup(context) {
                 )
                 if (edgeToEdge) {
                     viewer.setViewerFactory(object : ImageViewerDialogFragment.Factory() {
-                        override fun build() = EdgeToEdgeImageViewerDialogFragment()
+                        override fun build() = EdgeToEdgeImageViewerDialogFragment(
+                            theme.toAppearanceLightSystemBars()
+                        )
                     })
                 }
                 childView.setOnClickListener {
@@ -183,6 +185,13 @@ class CustomViewerCallback(private val childView: ImageView) : ViewerCallback {
 enum class Theme(val value: String) {
     Dark("dark"),
     Light("light");
+
+    fun toAppearanceLightSystemBars(): Boolean {
+        return when (this) {
+            Dark -> false
+            Light -> true
+        }
+    }
 
     fun toImageViewerTheme(): Int {
         return when (this) {

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -18,6 +18,7 @@ import com.bumptech.glide.Glide
 import com.facebook.react.views.image.ReactImageView
 import com.github.iielse.imageviewer.ImageViewerActionViewModel
 import com.github.iielse.imageviewer.ImageViewerBuilder
+import com.github.iielse.imageviewer.ImageViewerDialogFragment
 import com.github.iielse.imageviewer.R
 import com.github.iielse.imageviewer.core.ImageLoader
 import com.github.iielse.imageviewer.core.Photo
@@ -48,6 +49,7 @@ class GaleriaView(context: Context) : ViewGroup(context) {
     var theme: Theme = Theme.Dark
     var initialIndex: Int = 0
     var disableHiddenOriginalImage = false
+    var edgeToEdge = false
     var transitionOffsetY: Int? = null
     var transitionOffsetX: Int? = 0
     val viewModel: ImageViewerActionViewModel by lazy {
@@ -107,6 +109,11 @@ class GaleriaView(context: Context) : ViewGroup(context) {
                         }
                     }
                 )
+                if (edgeToEdge) {
+                    viewer.setViewerFactory(object : ImageViewerDialogFragment.Factory() {
+                        override fun build() = EdgeToEdgeImageViewerDialogFragment()
+                    })
+                }
                 childView.setOnClickListener {
                     setupConfig()
                     if (!disableHiddenOriginalImage) {
@@ -142,7 +149,11 @@ class GaleriaView(context: Context) : ViewGroup(context) {
     }
 
     private fun setupConfig() {
-        Config.TRANSITION_OFFSET_Y = transitionOffsetY ?: getStatusBarHeight()
+        Config.TRANSITION_OFFSET_Y = transitionOffsetY ?: when (edgeToEdge) {
+            true -> 0
+            false -> getStatusBarHeight()
+        }
+
         Config.TRANSITION_OFFSET_X = transitionOffsetX ?: 0
         Config.VIEWER_BACKGROUND_COLOR = theme.toImageViewerTheme()
     }

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Based on https://github.com/facebook/react-native/blob/v0.78.0/packages/react-native/ReactAndroid/src/main/res/views/modal/values/themes.xml#L5 -->
+    <style name="Theme.FullScreenDialog">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "license": "MIT",
   "homepage": "https://github.com/nandorojo/galeria#readme",
   "dependencies": {
-    "framer-motion": "^10.9.1"
+    "framer-motion": "^10.9.1",
+    "react-native-is-edge-to-edge": "^1.1.6"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -13,4 +13,5 @@ export type GaleriaViewProps = {
   __web?: ComponentProps<(typeof motion)['div']>
   style?: ViewStyle
   dynamicAspectRatio?: boolean
+  edgeToEdge?: boolean
 }

--- a/src/GaleriaView.android.tsx
+++ b/src/GaleriaView.android.tsx
@@ -4,9 +4,16 @@ import { GaleriaViewProps } from './Galeria.types'
 import { useContext } from 'react'
 import { GaleriaContext } from './context'
 import { Image } from 'react-native'
+import {
+  controlEdgeToEdgeValues,
+  isEdgeToEdge,
+} from 'react-native-is-edge-to-edge'
+
+const EDGE_TO_EDGE = isEdgeToEdge()
 
 const NativeImage = requireNativeView<
   GaleriaViewProps & {
+    edgeToEdge: boolean
     urls?: string[]
     theme: 'dark' | 'light'
   }
@@ -41,10 +48,17 @@ const Galeria = Object.assign(
     )
   },
   {
-    Image(props: GaleriaViewProps) {
+    Image({ edgeToEdge, ...props }: GaleriaViewProps) {
       const { theme, urls } = useContext(GaleriaContext)
+
+      if (__DEV__) {
+        // warn the user once about unnecessary defined prop
+        controlEdgeToEdgeValues({ edgeToEdge })
+      }
+
       return (
         <NativeImage
+          edgeToEdge={EDGE_TO_EDGE || (edgeToEdge ?? false)}
           theme={theme}
           urls={urls?.map((url) => {
             if (typeof url === 'string') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,6 +3132,7 @@ __metadata:
     prettier: "npm:^3.0.3"
     react-dom: "npm:18.3.1"
     react-native: "npm:0.77.1"
+    react-native-is-edge-to-edge: "npm:^1.1.6"
     react-native-web: "npm:^0.19.8"
   peerDependencies:
     expo: "*"
@@ -10377,6 +10378,16 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"react-native-is-edge-to-edge@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "react-native-is-edge-to-edge@npm:1.1.6"
+  peerDependencies:
+    react: ">=18.2.0"
+    react-native: ">=0.73.0"
+  checksum: 10c0/5690e521e8310d21643634a8d0dacd524e19b76695f347b26f649fcac156a7a901fd6daef7f78482381a41e8445f4552f40ade13790fdf112fab15b0f54dbabd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/a569b693-d3da-45e8-93c3-37d87db266d9

Following https://github.com/nandforojo/galeria/issues/16 (ping @hirbod)

This PR add support for edge-to-edge layout. It adds a new prop: `edgeToEdge`, that is always `true` when `react-native-edge-to-edge` is installed.

I would recommand to expose the `edgeToEdge` prop in the TypeScript types for non `react-native-edge-to-edge` users that also wants edge-to-edge (currently, it's not, check the `GaleriaViewProps` type vs the actual accepted `Galeria` props).