### PR TITLE
fix: add java version 17 for compileOptions and kotlinOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,15 @@ android {
     kotlinOptions {
       jvmTarget = JavaVersion.VERSION_11.majorVersion
     }
+  } else {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_17.majorVersion
+    }
   }
 
   namespace "nandorojo.modules.galeria"


### PR DESCRIPTION
```
 compileOptions {
      sourceCompatibility JavaVersion.VERSION_17
      targetCompatibility JavaVersion.VERSION_17
    }

    kotlinOptions {
      jvmTarget = JavaVersion.VERSION_17.majorVersion
    }
```
Adding `JavaVersion.VERSION_17` for the agpVersion with version more than 8 helps with the issue we are seeing on android!

Should resolve #20 

PS: I am not sure if this should be handled here in the library or in the actual project. Added here just in case! 