### PR TITLE
Optimise setup calls with view lifecycle `OnViewDidUpdateProps`

### DIFF
--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -5,6 +5,10 @@ public class GaleriaModule: Module {
     Name("Galeria")
     
     View(GaleriaView.self) {
+      OnViewDidUpdateProps {(view) in
+        view.setupImageView()
+      }
+
       Prop("urls") { (view, urls: [String]?) in
         view.urls = urls
       }

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -59,6 +59,7 @@ class GaleriaView: ExpoView {
   ) {
     let urlObjects = urls.compactMap(URL.init(string:))
     let options = buildImageViewerOptions()
+
     childImage.setupImageViewer(urls: urlObjects, initialIndex: initialIndex, options: options)
   }
 

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -31,21 +31,15 @@ class GaleriaView: ExpoView {
     }
   }
 
-  override func insertSubview(_ subview: UIView, at atIndex: Int) {
-    super.insertSubview(subview, at: atIndex)
-    if RCTIsNewArchEnabled() {
-      setupImageView()
-    }
-  }
-
-  var theme: Theme = .dark { didSet { setupImageView() } }
-  var urls: [String]? { didSet { setupImageView() } }
-  var initialIndex: Int? { didSet { setupImageView() } }
+  var theme: Theme = .dark
+  var urls: [String]?
+  var initialIndex: Int?
   var closeIconName: String?
   var rightNavItemIconName: String?
   let onPressRightNavItemIcon = EventDispatcher()
+  
 
-  func setupImageView() {
+  public func setupImageView() {
     let viewerTheme = theme.toImageViewerTheme()
     guard let childImage = getChildImageView() else {
       return
@@ -65,7 +59,6 @@ class GaleriaView: ExpoView {
   ) {
     let urlObjects = urls.compactMap(URL.init(string:))
     let options = buildImageViewerOptions()
-
     childImage.setupImageViewer(urls: urlObjects, initialIndex: initialIndex, options: options)
   }
 


### PR DESCRIPTION
Removed `didSet` calls for each prop and replaced with `OnViewDidUpdateProps` handler. This is not documented but it has been there for a [while](https://github.com/expo/expo/pull/19549) now.

With `OnViewDidUpdateProps`, Fabric does not need `insertSubview` as `OnViewDidUpdateProps` accommodates for both (prop + children changes). However, Paper still needs `insertReactSubview` override because there `OnViewDidUpdateProps` only accommodates pure prop changes, no child inserts, but it is still optimised as it removes individual `didSet` calls on initial mount.

This may or may not fix https://github.com/nandorojo/galeria/issues/19. I am still not able to repro it with @alantoa's approach. @alantoa @roshangm1 if anyone can consistently repro, please share a minimal repo!