### PR TITLE
feat: Add the option to use closeIconName on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "prettier": "^3.0.3",
     "react-dom": "18.3.1",
     "react-native": "0.77.1",
-    "react-native-web": "^0.19.8"
+    "react-native-web": "^0.19.8",
+    "sf-symbols-typescript": "^2.1.0"
   },
   "peerDependencies": {
     "expo": "*",

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -1,7 +1,7 @@
 import type { motion } from 'framer-motion'
 import type { ComponentProps } from 'react'
 import { ViewStyle } from 'react-native'
-import { SFSymbol } from 'sf-symbols-typescript'
+import type { SFSymbol } from 'sf-symbols-typescript'
 
 export type ChangeEventPayload = {
   value: string

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -1,6 +1,7 @@
 import type { motion } from 'framer-motion'
 import type { ComponentProps } from 'react'
 import { ViewStyle } from 'react-native'
+import { SFSymbol } from 'sf-symbols-typescript'
 
 export type ChangeEventPayload = {
   value: string
@@ -10,6 +11,7 @@ export type GaleriaViewProps = {
   index?: number
   id?: string
   children: React.ReactElement
+  closeIconName?: SFSymbol
   __web?: ComponentProps<(typeof motion)['div']>
   style?: ViewStyle
   dynamicAspectRatio?: boolean

--- a/src/GaleriaView.android.tsx
+++ b/src/GaleriaView.android.tsx
@@ -27,6 +27,7 @@ const Galeria = Object.assign(
     return (
       <GaleriaContext.Provider
         value={{
+          closeIconName: undefined,
           urls,
           theme,
           initialIndex: 0,

--- a/src/GaleriaView.ios.tsx
+++ b/src/GaleriaView.ios.tsx
@@ -4,10 +4,12 @@ import { GaleriaViewProps } from './Galeria.types'
 import { useContext } from 'react'
 import { GaleriaContext } from './context'
 import { Image } from 'react-native'
+import { SFSymbol } from 'sf-symbols-typescript'
 
 const NativeImage = requireNativeView<
   GaleriaViewProps & {
     urls?: string[]
+    closeIconName?: SFSymbol
     theme: 'dark' | 'light'
   }
 >('Galeria')
@@ -18,15 +20,17 @@ const noop = () => { }
 const Galeria = Object.assign(
   function Galeria({
     children,
+    closeIconName,
     urls,
     theme = 'dark',
     ids,
   }: {
     children: React.ReactNode
-  } & Partial<Pick<GaleriaContext, 'theme' | 'ids' | 'urls'>>) {
+  } & Partial<Pick<GaleriaContext, 'theme' | 'ids' | 'urls' | 'closeIconName'>>) {
     return (
       <GaleriaContext.Provider
         value={{
+          closeIconName,
           urls,
           theme,
           initialIndex: 0,
@@ -42,9 +46,10 @@ const Galeria = Object.assign(
   },
   {
     Image(props: GaleriaViewProps) {
-      const { theme, urls, initialIndex } = useContext(GaleriaContext)
+      const { theme, urls, initialIndex, closeIconName } = useContext(GaleriaContext)
       return (
         <NativeImage
+          closeIconName={closeIconName}
           theme={theme}
           urls={urls?.map((url) => {
             if (typeof url === 'string') {

--- a/src/GaleriaView.ios.tsx
+++ b/src/GaleriaView.ios.tsx
@@ -4,7 +4,7 @@ import { GaleriaViewProps } from './Galeria.types'
 import { useContext } from 'react'
 import { GaleriaContext } from './context'
 import { Image } from 'react-native'
-import { SFSymbol } from 'sf-symbols-typescript'
+import type { SFSymbol } from 'sf-symbols-typescript'
 
 const NativeImage = requireNativeView<
   GaleriaViewProps & {

--- a/src/GaleriaView.tsx
+++ b/src/GaleriaView.tsx
@@ -216,6 +216,7 @@ function Root({
   return (
     <GaleriaContext.Provider
       value={{
+        closeIconName: undefined,
         setOpen,
         urls,
         theme,

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,5 +1,6 @@
 import { ContextType, createContext } from 'react'
 import type { Image } from 'react-native'
+import { SFSymbol } from 'sf-symbols-typescript'
 
 type ImageSource = string | Parameters<typeof Image.resolveAssetSource>[0]
 
@@ -7,6 +8,7 @@ export const GaleriaContext = createContext({
   initialIndex: 0,
   open: false,
   urls: [] as unknown as undefined | ImageSource[],
+  closeIconName: undefined as undefined | SFSymbol,
   /**
    * @deprecated
    */

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,6 +1,6 @@
 import { ContextType, createContext } from 'react'
 import type { Image } from 'react-native'
-import { SFSymbol } from 'sf-symbols-typescript'
+import type { SFSymbol } from 'sf-symbols-typescript'
 
 type ImageSource = string | Parameters<typeof Image.resolveAssetSource>[0]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,6 +3133,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     react-native: "npm:0.77.1"
     react-native-web: "npm:^0.19.8"
+    sf-symbols-typescript: "npm:^2.1.0"
   peerDependencies:
     expo: "*"
     react: "*"
@@ -11221,6 +11222,13 @@ __metadata:
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
+  languageName: node
+  linkType: hard
+
+"sf-symbols-typescript@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "sf-symbols-typescript@npm:2.1.0"
+  checksum: 10c0/b6e2482c2b3ba785aa00770013e343a2175475b9cb7c8703c30a2ec1da8b41acd982db2d953877afb35af32a3dfba337d0b29e703c399cd2138c3cf68685c9c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adding the option to use closeIconName as a prop for iOS. I assume this should be implemented since we have the code in `GaleriaView.swift`, if not just close this.

Not a typescript wizard, so let me know if there’s something that should be changed. 


![Simulator Screenshot - iPhone 16 Pro - 2025-03-10 at 21 00 56](https://github.com/user-attachments/assets/2e25f58c-7f11-4bcd-ad0a-84a905cfa48d)
