### PR TITLE
fix: (ios) view recycling in fabric

### DIFF
--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -3,6 +3,7 @@ import ImageViewer_swift
 import UIKit
 
 class GaleriaView: ExpoView {
+  var childImageView: UIImageView?
   func getChildImageView() -> UIImageView? {
     var reactSubviews: [UIView]? = nil
     if RCTIsNewArchEnabled() {
@@ -16,6 +17,7 @@ class GaleriaView: ExpoView {
     for reactSubview in reactSubviews {
       for subview in reactSubview.subviews {
         if let imageView = subview as? UIImageView {
+          childImageView = imageView
           return imageView
         }
       }
@@ -29,6 +31,15 @@ class GaleriaView: ExpoView {
     if !RCTIsNewArchEnabled() {
       setupImageView()
     }
+  }
+
+
+  // https://github.com/nandorojo/galeria/issues/19
+  // Cleanup gesture recognizers from the image view to work with fabric view recycling
+  override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
+    childImageView?.gestureRecognizers?.removeAll()
+    childImageView = nil
+    super.unmountChildComponentView(childComponentView, index: index)
   }
 
   var theme: Theme = .dark

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -3,7 +3,8 @@ import ImageViewer_swift
 import UIKit
 
 class GaleriaView: ExpoView {
-  var childImageView: UIImageView?
+  private var childImageView: UIImageView?
+
   func getChildImageView() -> UIImageView? {
     var reactSubviews: [UIView]? = nil
     if RCTIsNewArchEnabled() {


### PR DESCRIPTION
Fix: https://github.com/nandorojo/galeria/issues/19

Clean up gesture recognizers on child unmount to support fabric view recycling.