### PR TITLE
add RCT_NEW_ARCH_ENABLED compiler flag

### DIFF
--- a/ios/Galeria.podspec
+++ b/ios/Galeria.podspec
@@ -2,6 +2,9 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_compiler_flags = '-DRCT_NEW_ARCH_ENABLED'
+
 Pod::Spec.new do |s|
   s.name           = 'Galeria'
   s.version        = package['version']
@@ -15,6 +18,8 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/nandorojo/galeria' }
   s.static_framework = true
 
+  s.compiler_flags = new_arch_compiler_flags if new_arch_enabled
+
   s.dependency 'ExpoModulesCore'
   s.dependency 'ImageViewer.swift', '~> 3.0'
   s.dependency 'ImageViewer.swift/Fetcher', '~> 3.0'
@@ -22,7 +27,8 @@ Pod::Spec.new do |s|
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+    'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    'OTHER_SWIFT_FLAGS' => "$(inherited) #{new_arch_enabled ? new_arch_compiler_flags : ''}"
   }
 
   s.source_files = "**/*.{h,m,swift}"

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -27,14 +27,15 @@ class GaleriaView: ExpoView {
     return nil
   }
 
+  #if !RCT_NEW_ARCH_ENABLED
   override func insertReactSubview(_ subview: UIView!, at atIndex: Int) {
     super.insertReactSubview(subview, at: atIndex)
-    if !RCTIsNewArchEnabled() {
-      setupImageView()
-    }
+    setupImageView()
   }
+  #endif
 
 
+  #if RCT_NEW_ARCH_ENABLED
   // https://github.com/nandorojo/galeria/issues/19
   // Cleanup gesture recognizers from the image view to work with fabric view recycling
   override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
@@ -42,6 +43,7 @@ class GaleriaView: ExpoView {
     childImageView = nil
     super.unmountChildComponentView(childComponentView, index: index)
   }
+  #endif
 
   var theme: Theme = .dark
   var urls: [String]?


### PR DESCRIPTION
Fixes - https://github.com/nandorojo/galeria/issues/19#issuecomment-2728310081. 

Use compiler flag instead of runtime check for new arch specific code. Tested on new and old arch in example app.
