### PR TITLE
Fix multiple images example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export const MutliImage = ({ style }) => (
        <Galeria.Image index={index} key={...}>
          <Image source={typeof url === 'string' ? { uri: url } : url} style={style} />
        </Galeria.Image>
-     )}
+     ))}
   </Galeria>
 )
 ```


### PR DESCRIPTION
A minor fix in the `README.md` file. The change corrects a syntax issue by adding a missing closing parenthesis in the `MutliImage` component example.