### PR TITLE
Always present image viewer from topmost view controller to fix modal-screen stacking

### DIFF
--- a/example/app/second-modal.tsx
+++ b/example/app/second-modal.tsx
@@ -1,14 +1,14 @@
 import { Image } from 'expo-image'
-import { useRouter } from 'expo-router'
 import { Galeria } from 'galeria'
-import { Button, StyleSheet, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import { urls } from '../constants/Images'
 
-export default function ModalScreen() {
-  const router = useRouter()
+export default function SecondModalScreen() {
   return (
     <View style={styles.container}>
-      <Galeria urls={urls} theme="dark">
+      <Text>Second Modal with Galeria</Text>
+
+      <Galeria urls={[urls[4]]} theme="dark">
         <Galeria.Image>
           <Image
             style={{
@@ -16,15 +16,10 @@ export default function ModalScreen() {
               width: 245,
               objectFit: 'cover',
             }}
-            source={{ uri: urls[0] }}
+            source={{ uri: urls[4] }}
           />
         </Galeria.Image>
       </Galeria>
-
-      <Button
-        title="Open new modal Modal"
-        onPress={() => router.push('/second-modal')}
-      />
     </View>
   )
 }

--- a/ios/ImageViewer.swift/UIImageView_Extensions.swift
+++ b/ios/ImageViewer.swift/UIImageView_Extensions.swift
@@ -147,6 +147,14 @@ extension UIImageView {
         addGestureRecognizer(_tapRecognizer!)
     }
     
+    private func topMostViewController(_ rootViewController: UIViewController?) -> UIViewController? {
+        var topController = rootViewController
+        while let presented = topController?.presentedViewController {
+            topController = presented
+        }
+        return topController
+    }
+    
     @objc
     private func showImageViewer(_ sender:TapWithDataRecognizer) {
         guard let sourceView = sender.view as? UIImageView else { return }
@@ -156,7 +164,9 @@ extension UIImageView {
             imageLoader: sender.imageLoader ?? URLSessionImageLoader(),
             options: sender.options,
             initialIndex: sender.initialIndex)
-        let presentFromVC = sender.from ?? vc
+     
+        let rootVC = sender.from ?? vc
+        let presentFromVC = topMostViewController(rootVC)
         presentFromVC?.present(imageCarousel, animated: true)
     }
 }


### PR DESCRIPTION
Fix for https://github.com/nandorojo/galeria/issues/35

Loops through all presented view controllers until the topmost (the currently visible/active) one is found, and uses that Galeria instance. 