### PR TITLE
fix: default to SDWebImage and fallback to URLSessionImageLoader

### DIFF
--- a/example/constants/Images.ts
+++ b/example/constants/Images.ts
@@ -4,6 +4,7 @@ import splash from '../assets/splash.png'
 
 export const urls = [
   'https://res.cloudinary.com/dn29xlaeh/image/upload/q_75,w_600,fl_lossy/beatgig-sandbox/chat/hmpschevbtbzjockgq6n',
+  'https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2hpc3NvbHo3cXh6eDBjODVtenByZGUwZjZqZGY0d25jbG9yeTdmMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uIJBFZoOaifHf52MER/giphy.gif',
   smallImage,
   splash,
   mediumImage,

--- a/ios/ImageViewer.swift/UIImageView_Extensions.swift
+++ b/ios/ImageViewer.swift/UIImageView_Extensions.swift
@@ -150,10 +150,18 @@ extension UIImageView {
     @objc
     private func showImageViewer(_ sender:TapWithDataRecognizer) {
         guard let sourceView = sender.view as? UIImageView else { return }
+        // Use SDWebImageLoader if available, otherwise fall back to URLSessionImageLoader
+        let defaultImageLoader: ImageLoader
+        #if canImport(SDWebImage)
+        defaultImageLoader = SDWebImageLoader()
+        #else
+        defaultImageLoader = URLSessionImageLoader()
+        #endif
+        
         let imageCarousel = ImageCarouselViewController.init(
             sourceView: sourceView,
             imageDataSource: sender.imageDatasource,
-            imageLoader: sender.imageLoader ?? URLSessionImageLoader(),
+            imageLoader: sender.imageLoader ?? defaultImageLoader,
             options: sender.options,
             initialIndex: sender.initialIndex)
         let presentFromVC = sender.from ?? vc


### PR DESCRIPTION
Currently all images are loaded via URLSessionImageLoader since it's the default loader and we never pass a specific loader when creating the ViewController. 

This PR sets SDWebImage as the default loader and falls back to URLSessionImageLoader if SDWebImage for some reason isn't available (should always be available since we install it). 


Fixes issue with displaying gifs https://github.com/nandorojo/galeria/issues/61 and probably adds alot of other nice stuff that SDWebImage has.