### PR TITLE
Gary/fix safe area

### DIFF
--- a/ios/GaleriaViewRegistry.swift
+++ b/ios/GaleriaViewRegistry.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+private final class WeakGaleriaViewRef {
+    weak var view: GaleriaView?
+    
+    init(_ view: GaleriaView) {
+        self.view = view
+    }
+}
+
+final class GaleriaViewRegistry {
+    static let shared = GaleriaViewRegistry()
+    
+    private var views: [String: [Int: WeakGaleriaViewRef]] = [:]
+    private let lock = NSLock()
+    
+    private init() {}
+    
+    func register(view: GaleriaView, groupId: String, index: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        if views[groupId] == nil {
+            views[groupId] = [:]
+        }
+        views[groupId]?[index] = WeakGaleriaViewRef(view)
+    }
+    
+    func unregister(groupId: String, index: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        views[groupId]?[index] = nil
+        
+        if views[groupId]?.isEmpty == true {
+            views[groupId] = nil
+        }
+    }
+    
+    func view(forGroupId groupId: String, index: Int) -> GaleriaView? {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        return views[groupId]?[index]?.view
+    }
+    
+    func cleanup() {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        for (groupId, indexMap) in views {
+            views[groupId] = indexMap.filter { $0.value.view != nil }
+            if views[groupId]?.isEmpty == true {
+                views[groupId] = nil
+            }
+        }
+    }
+}
+

--- a/ios/ImageViewer.swift/ImageViewerController.swift
+++ b/ios/ImageViewer.swift/ImageViewerController.swift
@@ -7,6 +7,9 @@ class ImageViewerController: UIViewController {
 
     var index: Int = 0
     var imageItem: ImageItem!
+    
+    /// Placeholder image to use while loading URL images (set before view loads)
+    var initialPlaceholder: UIImage?
 
     private var top: NSLayoutConstraint!
     private var leading: NSLayoutConstraint!
@@ -64,10 +67,16 @@ class ImageViewerController: UIViewController {
 
         switch imageItem {
         case .image(let img):
-            imageView.image = img
+            imageView.image = img ?? initialPlaceholder
             imageView.layoutIfNeeded()
         case .url(let url, let placeholder):
-            imageLoader.loadImage(url, placeholder: placeholder, imageView: imageView) { [weak self] _ in
+            // Use initialPlaceholder if no placeholder was provided with the URL
+            let effectivePlaceholder = placeholder ?? initialPlaceholder
+            if let effectivePlaceholder = effectivePlaceholder {
+                imageView.image = effectivePlaceholder
+                imageView.contentMode = .scaleAspectFit
+            }
+            imageLoader.loadImage(url, placeholder: effectivePlaceholder, imageView: imageView) { [weak self] _ in
                 DispatchQueue.main.async {
                     self?.layout()
                 }

--- a/ios/ImageViewer.swift/ImageViewerController.swift
+++ b/ios/ImageViewer.swift/ImageViewerController.swift
@@ -8,7 +8,6 @@ class ImageViewerController: UIViewController {
     var index: Int = 0
     var imageItem: ImageItem!
     
-    /// Placeholder image to use while loading URL images (set before view loads)
     var initialPlaceholder: UIImage?
 
     private var top: NSLayoutConstraint!
@@ -70,9 +69,8 @@ class ImageViewerController: UIViewController {
             imageView.image = img ?? initialPlaceholder
             imageView.layoutIfNeeded()
         case .url(let url, let placeholder):
-            // Use initialPlaceholder if no placeholder was provided with the URL
             let effectivePlaceholder = placeholder ?? initialPlaceholder
-            if let effectivePlaceholder = effectivePlaceholder {
+            if let effectivePlaceholder {
                 imageView.image = effectivePlaceholder
                 imageView.contentMode = .scaleAspectFit
             }

--- a/ios/ImageViewer.swift/ImageViewerController.swift
+++ b/ios/ImageViewer.swift/ImageViewerController.swift
@@ -144,7 +144,6 @@ extension ImageViewerController {
             return
         }
         
-        // Account for safe area when calculating scale
         let safeAreaInsets = view.safeAreaInsets
         let availableWidth = size.width - safeAreaInsets.left - safeAreaInsets.right
         let availableHeight = size.height - safeAreaInsets.top - safeAreaInsets.bottom
@@ -182,7 +181,6 @@ extension ImageViewerController {
         guard let image = imageView.image else { return }
         let imageSize = image.size
         
-        // Account for safe area when centering
         let safeAreaInsets = view.safeAreaInsets
         let availableWidth = size.width - safeAreaInsets.left - safeAreaInsets.right
         let availableHeight = size.height - safeAreaInsets.top - safeAreaInsets.bottom

--- a/ios/ImageViewer.swift/ImageViewerController.swift
+++ b/ios/ImageViewer.swift/ImageViewerController.swift
@@ -123,6 +123,11 @@ class ImageViewerController: UIViewController {
 
 extension ImageViewerController {
     
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        layout()
+    }
+    
     func updateMinMaxZoomScaleForSize(_ size: CGSize) {
         
         guard let image = imageView.image else { return }
@@ -132,14 +137,18 @@ extension ImageViewerController {
             return
         }
         
+        // Account for safe area when calculating scale
+        let safeAreaInsets = view.safeAreaInsets
+        let availableWidth = size.width - safeAreaInsets.left - safeAreaInsets.right
+        let availableHeight = size.height - safeAreaInsets.top - safeAreaInsets.bottom
         
         let minScale = min(
-            size.width/imageSize.width,   
-            size.height/imageSize.height)  
+            availableWidth/imageSize.width,   
+            availableHeight/imageSize.height)  
         
         let maxScale = max(
-            (size.width + 1.0) / imageSize.width,
-            (size.height + 1.0) / imageSize.height)
+            (availableWidth + 1.0) / imageSize.width,
+            (availableHeight + 1.0) / imageSize.height)
         
 
         scrollView.minimumZoomScale = minScale
@@ -166,16 +175,21 @@ extension ImageViewerController {
         guard let image = imageView.image else { return }
         let imageSize = image.size
         
+        // Account for safe area when centering
+        let safeAreaInsets = view.safeAreaInsets
+        let availableWidth = size.width - safeAreaInsets.left - safeAreaInsets.right
+        let availableHeight = size.height - safeAreaInsets.top - safeAreaInsets.bottom
+        
         let scaledImageWidth = imageSize.width * scrollView.zoomScale
         let scaledImageHeight = imageSize.height * scrollView.zoomScale
         
-        let yOffset = max(0, (size.height - scaledImageHeight) / 2)
-        top.constant = yOffset
-        bottom.constant = yOffset
+        let verticalPadding = max(0, (availableHeight - scaledImageHeight) / 2)
+        top.constant = verticalPadding + safeAreaInsets.top
+        bottom.constant = verticalPadding + safeAreaInsets.bottom
         
-        let xOffset = max(0, (size.width - scaledImageWidth) / 2)
-        leading.constant = xOffset
-        trailing.constant = xOffset
+        let horizontalPadding = max(0, (availableWidth - scaledImageWidth) / 2)
+        leading.constant = horizontalPadding + safeAreaInsets.left
+        trailing.constant = horizontalPadding + safeAreaInsets.right
         view.layoutIfNeeded()
     }
     

--- a/ios/ImageViewer.swift/ImageViewerRootView.swift
+++ b/ios/ImageViewer.swift/ImageViewerRootView.swift
@@ -124,13 +124,10 @@ class ImageViewerRootView: UIView, RootViewType {
             )
             self.initialViewController = initialVC
             
-            // Set the placeholder BEFORE accessing .view to avoid overwriting loaded images
-            // The placeholder will be used during URL loading and replaced with full-res when loaded
             if let sourceImage = self.sourceImage {
                 initialVC.initialPlaceholder = sourceImage
             }
             
-            // Now access .view which triggers viewDidLoad - the placeholder is already set
             initialVC.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
             pageViewController.setViewControllers([initialVC], direction: .forward, animated: false)
 
@@ -147,35 +144,47 @@ class ImageViewerRootView: UIView, RootViewType {
             action: #selector(dismissViewer)
         )
         closeBarButton.tintColor = theme.tintColor
-        navItem.leftBarButtonItem = closeBarButton
+        navItem.rightBarButtonItem = closeBarButton
         navBar.items = [navItem]
         addSubview(navBar)
     }
 
     private func applyOptions() {
+        let closeButton = navItem.rightBarButtonItem
+        
         options.forEach { option in
             switch option {
             case .theme(let newTheme):
                 self.theme = newTheme
                 backgroundView.backgroundColor = newTheme.color
-                navItem.leftBarButtonItem?.tintColor = newTheme.tintColor
+                closeButton?.tintColor = newTheme.tintColor
             case .closeIcon(let icon):
-                navItem.leftBarButtonItem?.image = icon
+                closeButton?.image = icon
             case .rightNavItemTitle(let title, let onTap):
-                navItem.rightBarButtonItem = UIBarButtonItem(
+                let customButton = UIBarButtonItem(
                     title: title,
                     style: .plain,
                     target: self,
                     action: #selector(didTapRightNavItem)
                 )
+                if let closeButton = closeButton {
+                    navItem.rightBarButtonItems = [closeButton, customButton]
+                } else {
+                    navItem.rightBarButtonItem = customButton
+                }
                 onRightNavBarTapped = onTap
             case .rightNavItemIcon(let icon, let onTap):
-                navItem.rightBarButtonItem = UIBarButtonItem(
+                let customButton = UIBarButtonItem(
                     image: icon,
                     style: .plain,
                     target: self,
                     action: #selector(didTapRightNavItem)
                 )
+                if let closeButton = closeButton {
+                    navItem.rightBarButtonItems = [closeButton, customButton]
+                } else {
+                    navItem.rightBarButtonItem = customButton
+                }
                 onRightNavBarTapped = onTap
             case .onIndexChange(let callback):
                 self.onIndexChange = callback

--- a/ios/ImageViewer.swift/ImageViewerRootView.swift
+++ b/ios/ImageViewer.swift/ImageViewerRootView.swift
@@ -31,7 +31,7 @@ class ImageViewerRootView: UIView, RootViewType {
     private lazy var navItem = UINavigationItem()
     private var onRightNavBarTapped: ((Int) -> Void)?
 
-    private var currentIndex: Int = 0
+    private(set) var currentIndex: Int = 0
     private var initialViewController: ImageViewerController?
 
     var currentImageView: UIImageView? {

--- a/ios/ImageViewer.swift/ImageViewerRootView.swift
+++ b/ios/ImageViewer.swift/ImageViewerRootView.swift
@@ -123,13 +123,16 @@ class ImageViewerRootView: UIView, RootViewType {
                 imageLoader: imageLoader
             )
             self.initialViewController = initialVC
+            
+            // Set the placeholder BEFORE accessing .view to avoid overwriting loaded images
+            // The placeholder will be used during URL loading and replaced with full-res when loaded
+            if let sourceImage = self.sourceImage {
+                initialVC.initialPlaceholder = sourceImage
+            }
+            
+            // Now access .view which triggers viewDidLoad - the placeholder is already set
             initialVC.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
             pageViewController.setViewControllers([initialVC], direction: .forward, animated: false)
-
-            if let sourceImage = self.sourceImage {
-                initialVC.imageView.image = sourceImage
-                initialVC.imageView.contentMode = .scaleAspectFit
-            }
 
             initialVC.view.setNeedsLayout()
             initialVC.view.layoutIfNeeded()


### PR DESCRIPTION
# What

- Update the `UIBarButtonItem` position to the right side
- Fix an image resolution issue, where after presenting an image it would display low resolution
- Respect the safe area if the image for images with large vertical aspect ratio
- Fix a bug where if I open an image, swipe to a different one, then dismiss, the transition should animate that current image back to its spot in the grid.