### PR TITLE
fix: add @Keep annotation to GaleriaView class

### DIFF
--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -11,6 +11,7 @@ import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.annotation.Keep
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.recyclerview.widget.RecyclerView
@@ -44,6 +45,7 @@ fun convertToPhotos(ids: Array<String>): List<Photo> {
 }
 
 
+@Keep
 class GaleriaView(context: Context) : ViewGroup(context) {
     private lateinit var viewer: ImageViewerBuilder
     lateinit var urls: Array<String>


### PR DESCRIPTION
I found when I enable R8 and render Galeria in my app, app will crash with `java.lang.IllegalStateException: Didn't find a correct constructor.`

So I added the @Keep annotation to GaleriaView to explicitly preserve the class and its constructor from being obfuscated or stripped. And it works.