### PR TITLE
feat: Add video support via mediaTypes prop

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,115 @@
+# Testing — Video Support in @nandorojo/galeria
+
+## 1. Basic usage (no breaking changes)
+
+Make sure existing image-only galleries still work exactly as before — no `mediaTypes` prop.
+
+```tsx
+<Galeria urls={['https://example.com/photo1.jpg', 'https://example.com/photo2.jpg']}>
+  <Galeria.Image index={0}>
+    <Image source={{ uri: 'https://example.com/photo1.jpg' }} style={{ width: 200, height: 200 }} />
+  </Galeria.Image>
+</Galeria>
+```
+
+**Expected:** Images open fullscreen with swipe paging, shared element transition, close button. Identical behaviour to the pre-video release.
+
+---
+
+## 2. Mixed photos + videos
+
+```tsx
+const urls = [
+  'https://example.com/photo1.jpg',
+  'https://example.com/clip.mp4',
+  'https://example.com/photo2.jpg',
+]
+const mediaTypes = ['image', 'video', 'image']
+
+<Galeria urls={urls} mediaTypes={mediaTypes}>
+  <Galeria.Image index={0}>
+    <Image source={{ uri: urls[0] }} style={{ width: 200, height: 200 }} />
+  </Galeria.Image>
+</Galeria>
+```
+
+**Expected:**
+- Page 0 → photo, pan-to-zoom works
+- Page 1 → video auto-plays with native controls (scrubber, play/pause)
+- Page 2 → photo again
+- Swiping from photo→video: video **auto-plays** on arrive
+- Swiping from video→photo: video **pauses**
+- Swiping back to video: video **resumes / replays**
+
+---
+
+## 3. All-video gallery
+
+```tsx
+const urls = [
+  'https://example.com/clip1.mp4',
+  'https://example.com/clip2.mp4',
+]
+const mediaTypes = ['video', 'video']
+
+<Galeria urls={urls} mediaTypes={mediaTypes}>
+  <Galeria.Image index={0}>
+    <Image source={{ uri: urls[0] }} style={{ width: 200, height: 200 }} />
+  </Galeria.Image>
+</Galeria>
+```
+
+**Expected:** Both pages play video. Only one video plays at a time.
+
+---
+
+## 4. Shared element transition (video thumbnail)
+
+The thumbnail `UIImageView` / `ImageView` that the video page displays before playback starts should be used for the push/pop shared-element transition — same as a regular photo.
+
+**Expected:** Tapping a thumbnail transitions smoothly into fullscreen; closing the viewer transitions back to the thumbnail position.
+
+---
+
+## 5. Pan-to-dismiss with video
+
+While a video is fullscreen (page 1), pan downward to dismiss.
+
+**Expected:** The dismiss gesture works (no zoom-scale check blocks it). The viewer closes with the reverse shared-element transition.
+
+---
+
+## 6. iOS-specific checks
+
+- AVPlayerViewController native controls (scrubber, AirPlay button, PiP) are visible.
+- Swiping away from a video page pauses the `AVPlayer`.
+- Looping: video loops after reaching the end.
+
+## 7. Android-specific checks
+
+- `MediaController` controls (play/pause, seek bar) show on tap.
+- First-frame thumbnail is rendered before playback starts.
+- Swiping away pauses the `VideoView`.
+
+---
+
+## Build
+
+### iOS
+```sh
+cd ios && pod install
+npx expo run:ios
+```
+
+### Android
+```sh
+npx expo run:android
+```
+
+---
+
+## Known limitations / future work
+
+- Android thumbnail uses Glide's `.frame(0L)` which requires `glide-video` or Glide >= 4.x with video support; if it fails the thumbnail will be blank (video still plays fine).
+- No custom seek bar on Android — relies on the built-in `MediaController`.
+- ExoPlayer support (better buffering, HLS, DRM) can be added later by swapping `VideoView` for an `ExoPlayer`-backed `PlayerView` in `GaleriaView.kt`.

--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -22,9 +22,11 @@ public class GaleriaModule: Module {
       Prop("theme") { (view, theme: Theme?) in
         view.theme = theme ?? .dark
       }
+
       Prop("closeIconName") { (view, closeIconName: String?) in
         view.closeIconName = closeIconName
       }
+
       Prop("rightNavItemIconName") { (view, rightNavItemIconName: String) in
         view.rightNavItemIconName = rightNavItemIconName
       }
@@ -37,6 +39,9 @@ public class GaleriaModule: Module {
         view.hidePageIndicators = hidePageIndicators ?? false
       }
 
+      Prop("mediaTypes") { (view, mediaTypes: [String]?) in
+        view.mediaTypes = mediaTypes
+      }
     }
   }
 

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -6,28 +6,28 @@ class GaleriaView: ExpoView {
   private weak var currentNavigationView: NavigationView?
   private weak var previousFirstResponder: UIResponder?
   private var isRegistered = false
-  
+
   var groupId: String? {
     guard let urls = urls, !urls.isEmpty else { return nil }
     return String(urls.joined(separator: ",").hashValue)
   }
-  
+
   deinit {
     unregisterFromRegistry()
   }
-  
+
   private func registerWithRegistry() {
     guard let groupId = groupId, let index = initialIndex else { return }
     GaleriaViewRegistry.shared.register(view: self, groupId: groupId, index: index)
     isRegistered = true
   }
-  
+
   private func unregisterFromRegistry() {
     guard isRegistered, let groupId = groupId, let index = initialIndex else { return }
     GaleriaViewRegistry.shared.unregister(groupId: groupId, index: index)
     isRegistered = false
   }
-  
+
   class func findView(groupId: String, index: Int) -> GaleriaView? {
     return GaleriaViewRegistry.shared.view(forGroupId: groupId, index: index)
   }
@@ -79,6 +79,9 @@ class GaleriaView: ExpoView {
   var rightNavItemIconName: String?
   var hideBlurOverlay: Bool = false
   var hidePageIndicators: Bool = false
+  /// Per-item media types. Must be same length as `urls`.
+  /// Supported values: "image", "video". Defaults to "image" when nil or out of bounds.
+  var mediaTypes: [String]?
   let onPressRightNavItemIcon = EventDispatcher()
   let onIndexChange = EventDispatcher()
 
@@ -113,7 +116,20 @@ class GaleriaView: ExpoView {
       return URL(fileURLWithPath: string)
     }
 
-    childImage.setupImageViewer(urls: urlObjects, initialIndex: initialIndex, options: options)
+    // Build ImageItem array respecting mediaTypes
+    let items: [ImageItem] = urlObjects.enumerated().map { (i, url) in
+      if let types = self.mediaTypes, i < types.count, types[i] == "video" {
+        return .video(url, placeholder: nil)
+      }
+      return .url(url, placeholder: nil)
+    }
+
+    let datasource = SimpleImageDatasource(imageItems: items)
+    childImage.setupImageViewer(
+      datasource: datasource,
+      initialIndex: initialIndex,
+      options: options
+    )
   }
 
   private func setupImageViewerWithSingleImage(
@@ -138,7 +154,6 @@ class GaleriaView: ExpoView {
         iconColor, renderingMode: .alwaysOriginal)
     {
       options.append(ImageViewerOption.closeIcon(closeIconImage))
-
     }
 
     if let rightIconName = rightNavItemIconName,
@@ -158,10 +173,10 @@ class GaleriaView: ExpoView {
         self?.onIndexChange(["currentIndex": index])
       })
 
-      options.append(
-        .onDismiss { [weak self] in
-            self?.restoreKeyboard()
-        })
+    options.append(
+      .onDismiss { [weak self] in
+        self?.restoreKeyboard()
+      })
 
     options.append(.hideBlurOverlay(hideBlurOverlay))
     options.append(.hidePageIndicators(hidePageIndicators))
@@ -199,17 +214,18 @@ extension GaleriaView: MatchTransitionDelegate {
     return imageView
   }
 
-    func matchTransitionWillBegin(transition: MatchTransition) {
-        guard previousFirstResponder == nil else { return }
-        
-        previousFirstResponder = UIResponder.currentFirstResponder
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-    }
-    
-    func restoreKeyboard() {
-        previousFirstResponder?.becomeFirstResponder()
-        previousFirstResponder = nil
-    }
+  func matchTransitionWillBegin(transition: MatchTransition) {
+    guard previousFirstResponder == nil else { return }
+
+    previousFirstResponder = UIResponder.currentFirstResponder
+    UIApplication.shared.sendAction(
+      #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+
+  func restoreKeyboard() {
+    previousFirstResponder?.becomeFirstResponder()
+    previousFirstResponder = nil
+  }
 
   private func findCornerRadius(for view: UIView) -> CGFloat? {
     var current: UIView? = view.superview
@@ -227,15 +243,16 @@ extension GaleriaView: MatchTransitionDelegate {
 }
 
 extension UIResponder {
-    private static weak var _currentFirstResponder: UIResponder?
-    
-    static var currentFirstResponder: UIResponder? {
-        _currentFirstResponder = nil
-        UIApplication.shared.sendAction(#selector(findFirstResponder(_:)), to: nil, from: nil, for: nil)
-        return _currentFirstResponder
-    }
-    
-    @objc private func findFirstResponder(_ sender: Any) {
-        UIResponder._currentFirstResponder = self
-    }
+  private static weak var _currentFirstResponder: UIResponder?
+
+  static var currentFirstResponder: UIResponder? {
+    _currentFirstResponder = nil
+    UIApplication.shared.sendAction(
+      #selector(findFirstResponder(_:)), to: nil, from: nil, for: nil)
+    return _currentFirstResponder
+  }
+
+  @objc private func findFirstResponder(_ sender: Any) {
+    UIResponder._currentFirstResponder = self
+  }
 }

--- a/ios/ImageViewer.swift/ImageItem.swift
+++ b/ios/ImageViewer.swift/ImageItem.swift
@@ -3,4 +3,5 @@ import UIKit
 public enum ImageItem {
     case image(UIImage?)
     case url(URL, placeholder: UIImage?)
+    case video(URL, placeholder: UIImage?)
 }

--- a/ios/ImageViewer.swift/ImageViewerRootView.swift
+++ b/ios/ImageViewer.swift/ImageViewerRootView.swift
@@ -1,5 +1,16 @@
 import UIKit
 
+// MARK: - Protocol shared by ImageViewerController and VideoViewerController
+
+protocol GaleriaPageViewController: AnyObject {
+    var index: Int { get }
+}
+
+extension ImageViewerController: GaleriaPageViewController {}
+extension VideoViewerController: GaleriaPageViewController {}
+
+// MARK: - ImageViewerRootView
+
 class ImageViewerRootView: UIView, RootViewType {
     let transition = MatchTransition()
 
@@ -33,23 +44,29 @@ class ImageViewerRootView: UIView, RootViewType {
     private var onRightNavBarTapped: ((Int) -> Void)?
 
     private(set) var currentIndex: Int = 0
-    private var initialViewController: ImageViewerController?
+    /// Holds the initial VC (image or video) before pageVC takes over.
+    private var initialViewController: UIViewController?
+
+    // MARK: - Current views (for transition matching & pan dismiss)
 
     var currentImageView: UIImageView? {
-        if let vc = pageViewController?.viewControllers?.first as? ImageViewerController {
-            return vc.imageView
+        let vc = pageViewController?.viewControllers?.first ?? initialViewController
+        if let imageVC = vc as? ImageViewerController {
+            return imageVC.imageView
         }
-        if let vc = initialViewController {
-            return vc.imageView
+        if let videoVC = vc as? VideoViewerController {
+            return videoVC.thumbnailImageView
         }
         return nil
     }
 
     var currentScrollView: UIScrollView? {
-        if let vc = pageViewController?.viewControllers?.first as? ImageViewerController {
-            return vc.scrollView
+        let vc = pageViewController?.viewControllers?.first ?? initialViewController
+        if let imageVC = vc as? ImageViewerController {
+            return imageVC.scrollView
         }
-        return initialViewController?.scrollView
+        // Videos don't have a scroll view — returning nil lets pan dismiss work freely
+        return nil
     }
 
     var preferredStatusBarStyle: UIStatusBarStyle {
@@ -109,6 +126,8 @@ class ImageViewerRootView: UIView, RootViewType {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Setup
+
     private func setupViews() {
         addSubview(backgroundView)
 
@@ -125,17 +144,13 @@ class ImageViewerRootView: UIView, RootViewType {
         addSubview(pageViewController.view)
 
         if let datasource = imageDatasource {
-            let initialVC = ImageViewerController(
-                index: initialIndex,
-                imageItem: datasource.imageItem(at: initialIndex),
-                imageLoader: imageLoader
-            )
+            let initialVC = makeViewController(for: initialIndex, datasource: datasource)
             self.initialViewController = initialVC
-            
-            if let sourceImage = self.sourceImage {
-                initialVC.initialPlaceholder = sourceImage
+
+            if let imageVC = initialVC as? ImageViewerController, let sourceImage = self.sourceImage {
+                imageVC.initialPlaceholder = sourceImage
             }
-            
+
             initialVC.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
             pageViewController.setViewControllers([initialVC], direction: .forward, animated: false)
 
@@ -157,9 +172,26 @@ class ImageViewerRootView: UIView, RootViewType {
         addSubview(navBar)
     }
 
+    // MARK: - Factory
+
+    /// Creates the correct VC type (image or video) for the given index.
+    private func makeViewController(for index: Int, datasource: ImageDataSource) -> UIViewController {
+        let item = datasource.imageItem(at: index)
+        let vc: UIViewController
+        if case .video(let url, let placeholder) = item {
+            let videoVC = VideoViewerController(index: index, videoURL: url, placeholder: placeholder)
+            vc = videoVC
+        } else {
+            let imageVC = ImageViewerController(index: index, imageItem: item, imageLoader: imageLoader)
+            vc = imageVC
+        }
+        vc.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
+        return vc
+    }
+
     private func applyOptions() {
         let closeButton = navItem.rightBarButtonItem
-        
+
         options.forEach { option in
             switch option {
             case .theme(let newTheme):
@@ -217,6 +249,8 @@ class ImageViewerRootView: UIView, RootViewType {
         addGestureRecognizer(singleTapGesture)
     }
 
+    // MARK: - Layout
+
     override func layoutSubviews() {
         super.layoutSubviews()
         backgroundView.frame = bounds
@@ -240,6 +274,8 @@ class ImageViewerRootView: UIView, RootViewType {
         )
     }
 
+    // MARK: - Actions
+
     @objc private func dismissViewer() {
         navigationView?.popView(animated: true)
     }
@@ -256,16 +292,19 @@ class ImageViewerRootView: UIView, RootViewType {
     }
 }
 
+// MARK: - TransitionProvider
+
 extension ImageViewerRootView: TransitionProvider {
     func transitionFor(presenting: Bool, otherView: UIView) -> Transition? {
         return transition
     }
 }
 
+// MARK: - MatchTransitionDelegate
+
 extension ImageViewerRootView: MatchTransitionDelegate {
     func matchedViewFor(transition: MatchTransition, otherView: UIView) -> UIView? {
-        let imageView = currentImageView
-        return imageView
+        return currentImageView
     }
 
     func matchTransitionWillBegin(transition: MatchTransition) {
@@ -274,11 +313,14 @@ extension ImageViewerRootView: MatchTransitionDelegate {
     }
 }
 
+// MARK: - UIGestureRecognizerDelegate
+
 extension ImageViewerRootView: UIGestureRecognizerDelegate {
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if let scrollView = currentScrollView {
             return scrollView.zoomScale <= scrollView.minimumZoomScale + 0.01
         }
+        // No scroll view (e.g. video) — always allow pan-to-dismiss
         return true
     }
 
@@ -290,57 +332,49 @@ extension ImageViewerRootView: UIGestureRecognizerDelegate {
     }
 }
 
+// MARK: - UIPageViewControllerDataSource
+
 extension ImageViewerRootView: UIPageViewControllerDataSource {
     func pageViewController(
         _ pageViewController: UIPageViewController,
         viewControllerBefore viewController: UIViewController
     ) -> UIViewController? {
-        guard let vc = viewController as? ImageViewerController,
+        guard let indexed = viewController as? GaleriaPageViewController,
               let datasource = imageDatasource,
-              vc.index > 0 else {
+              indexed.index > 0 else {
             return nil
         }
 
-        let newIndex = vc.index - 1
-        let newVC = ImageViewerController(
-            index: newIndex,
-            imageItem: datasource.imageItem(at: newIndex),
-            imageLoader: imageLoader
-        )
-        newVC.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
-        return newVC
+        let newIndex = indexed.index - 1
+        return makeViewController(for: newIndex, datasource: datasource)
     }
 
     func pageViewController(
         _ pageViewController: UIPageViewController,
         viewControllerAfter viewController: UIViewController
     ) -> UIViewController? {
-        guard let vc = viewController as? ImageViewerController,
+        guard let indexed = viewController as? GaleriaPageViewController,
               let datasource = imageDatasource,
-              vc.index < datasource.numberOfImages() - 1 else {
+              indexed.index < datasource.numberOfImages() - 1 else {
             return nil
         }
 
-        let newIndex = vc.index + 1
-        let newVC = ImageViewerController(
-            index: newIndex,
-            imageItem: datasource.imageItem(at: newIndex),
-            imageLoader: imageLoader
-        )
-        newVC.view.gestureRecognizers?.removeAll(where: { $0 is UIPanGestureRecognizer })
-        return newVC
+        let newIndex = indexed.index + 1
+        return makeViewController(for: newIndex, datasource: datasource)
     }
-    
+
     func presentationCount(for pageViewController: UIPageViewController) -> Int {
         guard !hidePageIndicators else { return 0 }
         let count = imageDatasource?.numberOfImages() ?? 0
         return count > 1 ? count : 0
     }
-    
+
     func presentationIndex(for pageViewController: UIPageViewController) -> Int {
         return currentIndex
     }
 }
+
+// MARK: - UIPageViewControllerDelegate
 
 extension ImageViewerRootView: UIPageViewControllerDelegate {
     func pageViewController(
@@ -349,9 +383,25 @@ extension ImageViewerRootView: UIPageViewControllerDelegate {
         previousViewControllers: [UIViewController],
         transitionCompleted completed: Bool
     ) {
-        if completed, let currentVC = pageViewController.viewControllers?.first as? ImageViewerController {
-            currentIndex = currentVC.index
-            onIndexChange?(currentIndex)
+        guard completed else { return }
+
+        // Pause any video that was previously playing
+        for previous in previousViewControllers {
+            if let videoVC = previous as? VideoViewerController {
+                videoVC.pause()
+            }
+        }
+
+        if let currentVC = pageViewController.viewControllers?.first {
+            // Auto-play if the new page is a video
+            if let videoVC = currentVC as? VideoViewerController {
+                videoVC.play()
+            }
+
+            if let indexed = currentVC as? GaleriaPageViewController {
+                currentIndex = indexed.index
+                onIndexChange?(currentIndex)
+            }
         }
     }
 }

--- a/ios/ImageViewer.swift/VideoViewerController.swift
+++ b/ios/ImageViewer.swift/VideoViewerController.swift
@@ -1,0 +1,138 @@
+import UIKit
+import AVKit
+import AVFoundation
+
+/// A view controller that plays a video fullscreen inside the image viewer page controller.
+/// Mirrors the structure of `ImageViewerController` but uses AVPlayerViewController for playback.
+class VideoViewerController: UIViewController {
+
+    // MARK: - Public properties
+
+    var index: Int
+    let videoURL: URL
+    let placeholder: UIImage?
+
+    /// The thumbnail/poster image view used for shared element transitions.
+    /// Sits behind the player and is visible before playback starts.
+    private(set) var thumbnailImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFit
+        iv.clipsToBounds = true
+        iv.backgroundColor = .clear
+        return iv
+    }()
+
+    // MARK: - Private properties
+
+    private var playerViewController: AVPlayerViewController?
+    private var player: AVPlayer?
+
+    // MARK: - Init
+
+    init(index: Int, videoURL: URL, placeholder: UIImage?) {
+        self.index = index
+        self.videoURL = videoURL
+        self.placeholder = placeholder
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View lifecycle
+
+    override func loadView() {
+        let view = UIView()
+        view.backgroundColor = .clear
+        self.view = view
+
+        // Thumbnail sits behind everything — used for transition matching
+        thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(thumbnailImageView)
+        NSLayoutConstraint.activate([
+            thumbnailImageView.topAnchor.constraint(equalTo: view.topAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            thumbnailImageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Show poster / placeholder right away
+        if let placeholder = placeholder {
+            thumbnailImageView.image = placeholder
+        }
+
+        setupPlayer()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        play()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        pause()
+    }
+
+    // MARK: - Player setup
+
+    private func setupPlayer() {
+        let playerItem = AVPlayerItem(url: videoURL)
+        let avPlayer = AVPlayer(playerItem: playerItem)
+        self.player = avPlayer
+
+        let pvc = AVPlayerViewController()
+        pvc.player = avPlayer
+        pvc.showsPlaybackControls = true
+        // Use a transparent background so our black background view shows through
+        pvc.view.backgroundColor = .clear
+
+        addChild(pvc)
+
+        pvc.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(pvc.view)
+        NSLayoutConstraint.activate([
+            pvc.view.topAnchor.constraint(equalTo: view.topAnchor),
+            pvc.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            pvc.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pvc.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        pvc.didMove(toParent: self)
+        self.playerViewController = pvc
+
+        // Loop playback
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(playerItemDidReachEnd),
+            name: .AVPlayerItemDidPlayToEndTime,
+            object: playerItem
+        )
+    }
+
+    @objc private func playerItemDidReachEnd(_ notification: Notification) {
+        player?.seek(to: .zero)
+        player?.play()
+    }
+
+    // MARK: - Playback control
+
+    func play() {
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        player?.pause()
+        player = nil
+    }
+}

--- a/src/GaleriaView.android.tsx
+++ b/src/GaleriaView.android.tsx
@@ -17,6 +17,7 @@ const NativeImage = requireNativeView<
     urls?: string[]
     theme: 'dark' | 'light'
     onIndexChange?: (event: GaleriaIndexChangedEvent) => void
+    mediaTypes?: string[]
   }
 >('Galeria')
 
@@ -28,9 +29,10 @@ const Galeria = Object.assign(
     urls,
     theme = 'dark',
     ids,
+    mediaTypes,
   }: {
     children: React.ReactNode
-  } & Partial<Pick<GaleriaContext, 'theme' | 'ids' | 'urls'>>) {
+  } & Partial<Pick<GaleriaContext, 'theme' | 'ids' | 'urls' | 'mediaTypes'>>) {
     return (
       <GaleriaContext.Provider
         value={{
@@ -44,6 +46,7 @@ const Galeria = Object.assign(
           src: '',
           setOpen: noop,
           ids,
+          mediaTypes,
         }}
       >
         {children}
@@ -52,7 +55,7 @@ const Galeria = Object.assign(
   },
   {
     Image({ edgeToEdge, ...props }: GaleriaViewProps) {
-      const { theme, urls } = useContext(GaleriaContext)
+      const { theme, urls, mediaTypes } = useContext(GaleriaContext)
 
       if (__DEV__) {
         // warn the user once about unnecessary defined prop
@@ -71,6 +74,7 @@ const Galeria = Object.assign(
 
             return Image.resolveAssetSource(url).uri
           })}
+          mediaTypes={mediaTypes}
           {...props}
         />
       )

--- a/src/GaleriaView.ios.tsx
+++ b/src/GaleriaView.ios.tsx
@@ -14,6 +14,7 @@ const NativeImage = requireNativeView<
     onIndexChange?: (event: GaleriaIndexChangedEvent) => void
     hideBlurOverlay?: boolean
     hidePageIndicators?: boolean
+    mediaTypes?: string[]
   }
 >('Galeria')
 
@@ -28,10 +29,20 @@ const Galeria = Object.assign(
     ids,
     hideBlurOverlay = false,
     hidePageIndicators = false,
+    mediaTypes,
   }: {
     children: React.ReactNode
   } & Partial<
-    Pick<GaleriaContext, 'theme' | 'ids' | 'urls' | 'closeIconName' | 'hideBlurOverlay' | 'hidePageIndicators'>
+    Pick<
+      GaleriaContext,
+      | 'theme'
+      | 'ids'
+      | 'urls'
+      | 'closeIconName'
+      | 'hideBlurOverlay'
+      | 'hidePageIndicators'
+      | 'mediaTypes'
+    >
   >) {
     return (
       <GaleriaContext.Provider
@@ -46,6 +57,7 @@ const Galeria = Object.assign(
           ids,
           hideBlurOverlay,
           hidePageIndicators,
+          mediaTypes,
         }}
       >
         {children}
@@ -54,8 +66,15 @@ const Galeria = Object.assign(
   },
   {
     Image(props: GaleriaViewProps) {
-      const { theme, urls, initialIndex, closeIconName, hideBlurOverlay, hidePageIndicators } =
-        useContext(GaleriaContext)
+      const {
+        theme,
+        urls,
+        initialIndex,
+        closeIconName,
+        hideBlurOverlay,
+        hidePageIndicators,
+        mediaTypes,
+      } = useContext(GaleriaContext)
       return (
         <NativeImage
           onIndexChange={props.onIndexChange}
@@ -71,6 +90,7 @@ const Galeria = Object.assign(
             return Image.resolveAssetSource(url).uri
           })}
           index={initialIndex}
+          mediaTypes={mediaTypes}
           {...props}
         />
       )

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -22,6 +22,11 @@ export const GaleriaContext = createContext({
   src: '',
   hideBlurOverlay: false,
   hidePageIndicators: false,
+  /**
+   * Per-item media types. Must be same length as `urls`.
+   * Accepted values: "image" | "video". Defaults to "image" when omitted.
+   */
+  mediaTypes: undefined as string[] | undefined,
 })
 
 export type GaleriaContext = ContextType<typeof GaleriaContext>


### PR DESCRIPTION
Adds video playback support to Galeria's fullscreen viewer. Users can now swipe between photos and videos in the same gallery.

## Changes
- New `mediaTypes` prop (`string[]`) — e.g. `['image', 'video', 'image']`
- New `VideoViewerController.swift` — embeds `AVPlayerViewController` with native controls, auto-play/pause/loop
- `ImageItem` enum gets `.video(URL, placeholder)` case
- `ImageViewerRootView` — factory pattern creates correct VC per page, pauses video on swipe away, plays on swipe to
- Shared element transitions work via thumbnail `UIImageView`
- Pan-to-dismiss works for video pages (no scroll view blocking)
- TypeScript: `mediaTypes` threaded through context on iOS and Android

## Backward compatible
No `mediaTypes` prop = all items treated as images. Zero changes to existing behavior.

Closes #4