### PR TITLE
fix(ios): register onPressRightNavItemIcon event in module manifest

### DIFF
--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -5,7 +5,7 @@ public class GaleriaModule: Module {
     Name("Galeria")
 
     View(GaleriaView.self) {
-      Events("onIndexChange")
+      Events("onIndexChange", "onPressRightNavItemIcon")
 
       OnViewDidUpdateProps { (view) in
         view.setupImageView()

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -15,16 +15,23 @@ type GaleriaIndexChangedPayload = {
 export type GaleriaIndexChangedEvent =
   NativeSyntheticEvent<GaleriaIndexChangedPayload>
 
+export type GaleriaRightNavItemPressedEvent =
+  NativeSyntheticEvent<{ index: number }>
+
 export interface GaleriaViewProps {
   index?: number
   id?: string
   children: React.ReactElement
   closeIconName?: SFSymbol
+  /** iOS only: SF Symbol name for an action button shown in the viewer's top-right nav bar. */
+  rightNavItemIconName?: SFSymbol
   __web?: ComponentProps<(typeof motion)['div']>
   style?: ViewStyle
   dynamicAspectRatio?: boolean
   edgeToEdge?: boolean
   onIndexChange?: (event: GaleriaIndexChangedEvent) => void
+  /** iOS only: fired when the right nav item button is tapped inside the viewer. */
+  onPressRightNavItemIcon?: (event: GaleriaRightNavItemPressedEvent) => void
   hideBlurOverlay?: boolean
   hidePageIndicators?: boolean
 }


### PR DESCRIPTION
The right-nav-item-icon feature was already implemented native-side: the iOS module registers the rightNavItemIconName Prop, GaleriaView declares an onPressRightNavItemIcon EventDispatcher, and the button's onTap closure fires self.onPressRightNavItemIcon(["index": index]). However the event never reached JS because the module manifest only declared Events("onIndexChange") and Expo Modules silently drops events not in the manifest.

Add "onPressRightNavItemIcon" to Events() and expose rightNavItemIconName + onPressRightNavItemIcon in the TypeScript types so the existing native feature is actually usable from JS.