### PR TITLE
feat: add onLongPress event for the inline trigger image

### DIFF
--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
@@ -17,7 +17,8 @@ class GaleriaModule : Module() {
         // the view definition: Prop, Events.
         View(GaleriaView::class) {
             Events(
-                "onIndexChange"
+                "onIndexChange",
+                "onLongPress"
             )
             // Defines a setter for the `name` prop.
             Prop("theme") { view: GaleriaView, theme: Theme ->

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -50,6 +50,7 @@ class GaleriaView(context: Context) : ViewGroup(context) {
     private lateinit var viewer: ImageViewerBuilder
     lateinit var urls: Array<String>
     val onIndexChange by EventDispatcher()
+    val onLongPress by EventDispatcher()
     var theme: Theme = Theme.Dark
     var initialIndex: Int = 0
     var disableHiddenOriginalImage = false
@@ -130,6 +131,10 @@ class GaleriaView(context: Context) : ViewGroup(context) {
 
                     viewer.show()
 
+                }
+                childView.setOnLongClickListener {
+                    onLongPress(emptyMap<String, Any>())
+                    true
                 }
             } else if (childView is ViewGroup) {
                 setupImageViewer(childView)

--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -5,7 +5,7 @@ public class GaleriaModule: Module {
     Name("Galeria")
 
     View(GaleriaView.self) {
-      Events("onIndexChange")
+      Events("onIndexChange", "onLongPress")
 
       OnViewDidUpdateProps { (view) in
         view.setupImageView()

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -54,6 +54,7 @@ class GaleriaView: ExpoView {
   var hidePageIndicators: Bool = false
   let onPressRightNavItemIcon = EventDispatcher()
   let onIndexChange = EventDispatcher()
+  let onLongPress = EventDispatcher()
 
   public func setupImageView() {
     // Clean up previous state for Fabric view recycling (see #19)
@@ -73,6 +74,22 @@ class GaleriaView: ExpoView {
         childImage, urls: urls, initialIndex: initialIndex, viewerTheme: viewerTheme)
     } else {
       setupImageViewerWithSingleImage(childImage, viewerTheme: viewerTheme)
+    }
+
+    attachLongPressRecognizer(to: childImage)
+  }
+
+  private func attachLongPressRecognizer(to imageView: UIImageView) {
+    let longPress = UILongPressGestureRecognizer(
+      target: self, action: #selector(handleLongPress(_:)))
+    longPress.minimumPressDuration = 0.5
+    imageView.addGestureRecognizer(longPress)
+    imageView.isUserInteractionEnabled = true
+  }
+
+  @objc private func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
+    if recognizer.state == .began {
+      onLongPress()
     }
   }
 

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -15,6 +15,8 @@ type GaleriaIndexChangedPayload = {
 export type GaleriaIndexChangedEvent =
   NativeSyntheticEvent<GaleriaIndexChangedPayload>
 
+export type GaleriaLongPressEvent = NativeSyntheticEvent<Record<string, never>>
+
 export interface GaleriaViewProps {
   index?: number
   id?: string
@@ -25,6 +27,8 @@ export interface GaleriaViewProps {
   dynamicAspectRatio?: boolean
   edgeToEdge?: boolean
   onIndexChange?: (event: GaleriaIndexChangedEvent) => void
+  /** Fired on long-press of the inline trigger image, before the viewer opens. */
+  onLongPress?: (event: GaleriaLongPressEvent) => void
   hideBlurOverlay?: boolean
   hidePageIndicators?: boolean
 }


### PR DESCRIPTION
Add an onLongPress event that fires on long-press of the source image (the image, before the viewer opens) on both iOS and Android. Useful for context menus — Save / Share / Copy actions, secondary affordances on a thumbnail that can also be tapped to open the viewer.

iOS: attach a UILongPressGestureRecognizer to the source UIImageView at the end of setupImageView() (after the existing tap setup, and after gestureRecognizers?.removeAll() so the recognizer survives Fabric view recycling). Fire on .began with a 0.5s minimumPressDuration to match the standard iOS long-press threshold. Tap and long-press recognizers coexist naturally via UIKit's gesture system — no require(toFail:) needed.

Android: add setOnLongClickListener next to the existing setOnClickListener on the source ImageView; return true to consume the event so the regular click does not also fire.