### PR TITLE
feat(ios): add onDismiss event for the fullscreen viewer

### DIFF
--- a/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/EdgeToEdgeImageViewerDialogFragment.kt
@@ -1,15 +1,32 @@
 package nandorojo.modules.galeria
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.github.iielse.imageviewer.ImageViewerDialogFragment
 
-class EdgeToEdgeImageViewerDialogFragment(private val isAppearanceLightSystemBars: Boolean) :
-    ImageViewerDialogFragment() {
+/**
+ * Subclass of [ImageViewerDialogFragment] used by Galeria.
+ *
+ * Two responsibilities:
+ *   1. When [isAppearanceLightSystemBars] is non-null, present an edge-to-edge
+ *      dialog with the system bars colored to match the light/dark theme.
+ *      When null, fall through to the library's default dialog.
+ *   2. Forward the dialog's onDismiss to [onDismissCallback], so the JS side
+ *      can be notified when the viewer is dismissed (any dismissal mechanism:
+ *      swipe-to-dismiss, system back button, programmatic dismiss).
+ */
+class EdgeToEdgeImageViewerDialogFragment(
+    private val isAppearanceLightSystemBars: Boolean?,
+    private val onDismissCallback: () -> Unit,
+) : ImageViewerDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        if (isAppearanceLightSystemBars == null) {
+            return super.onCreateDialog(savedInstanceState)
+        }
         return Dialog(requireActivity(), R.style.Theme_FullScreenDialog).apply {
             setCanceledOnTouchOutside(true)
 
@@ -22,5 +39,10 @@ class EdgeToEdgeImageViewerDialogFragment(private val isAppearanceLightSystemBar
                 }
             }
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onDismissCallback()
     }
 }

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
@@ -17,7 +17,8 @@ class GaleriaModule : Module() {
         // the view definition: Prop, Events.
         View(GaleriaView::class) {
             Events(
-                "onIndexChange"
+                "onIndexChange",
+                "onDismiss"
             )
             // Defines a setter for the `name` prop.
             Prop("theme") { view: GaleriaView, theme: Theme ->

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -50,6 +50,7 @@ class GaleriaView(context: Context) : ViewGroup(context) {
     private lateinit var viewer: ImageViewerBuilder
     lateinit var urls: Array<String>
     val onIndexChange by EventDispatcher()
+    val onDismiss by EventDispatcher()
     var theme: Theme = Theme.Dark
     var initialIndex: Int = 0
     var disableHiddenOriginalImage = false
@@ -113,13 +114,13 @@ class GaleriaView(context: Context) : ViewGroup(context) {
                         }
                     }
                 )
-                if (edgeToEdge) {
-                    viewer.setViewerFactory(object : ImageViewerDialogFragment.Factory() {
-                        override fun build() = EdgeToEdgeImageViewerDialogFragment(
-                            theme.toAppearanceLightSystemBars()
-                        )
-                    })
-                }
+                viewer.setViewerFactory(object : ImageViewerDialogFragment.Factory() {
+                    override fun build() = EdgeToEdgeImageViewerDialogFragment(
+                        isAppearanceLightSystemBars =
+                            if (edgeToEdge) theme.toAppearanceLightSystemBars() else null,
+                        onDismissCallback = { onDismiss(emptyMap<String, Any>()) },
+                    )
+                })
                 childView.setOnClickListener {
                     setupConfig()
                     if (!disableHiddenOriginalImage) {

--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -5,7 +5,7 @@ public class GaleriaModule: Module {
     Name("Galeria")
 
     View(GaleriaView.self) {
-      Events("onIndexChange")
+      Events("onIndexChange", "onDismiss")
 
       OnViewDidUpdateProps { (view) in
         view.setupImageView()

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -54,6 +54,7 @@ class GaleriaView: ExpoView {
   var hidePageIndicators: Bool = false
   let onPressRightNavItemIcon = EventDispatcher()
   let onIndexChange = EventDispatcher()
+  let onDismiss = EventDispatcher()
 
   public func setupImageView() {
     // Clean up previous state for Fabric view recycling (see #19)
@@ -139,6 +140,7 @@ class GaleriaView: ExpoView {
       options.append(
         .onDismiss { [weak self] in
             self?.restoreKeyboard()
+            self?.onDismiss()
         })
 
     options.append(.hideBlurOverlay(hideBlurOverlay))

--- a/src/Galeria.types.ts
+++ b/src/Galeria.types.ts
@@ -15,6 +15,8 @@ type GaleriaIndexChangedPayload = {
 export type GaleriaIndexChangedEvent =
   NativeSyntheticEvent<GaleriaIndexChangedPayload>
 
+export type GaleriaDismissEvent = NativeSyntheticEvent<Record<string, never>>
+
 export interface GaleriaViewProps {
   index?: number
   id?: string
@@ -25,6 +27,8 @@ export interface GaleriaViewProps {
   dynamicAspectRatio?: boolean
   edgeToEdge?: boolean
   onIndexChange?: (event: GaleriaIndexChangedEvent) => void
+  /** Fired after the fullscreen viewer is dismissed. */
+  onDismiss?: (event: GaleriaDismissEvent) => void
   hideBlurOverlay?: boolean
   hidePageIndicators?: boolean
 }


### PR DESCRIPTION
Add a JS-level signal for when the fullscreen viewer has been dismissed. Apps that compose Galeria with their own UI (e.g. a bottom sheet that hosts the trigger image) need to know when the viewer goes away — to clean up state, unmount, or coordinate animations.

iOS: chain into the existing internal .onDismiss ImageViewerOption (already wired for keyboard restoration via restoreKeyboard()) and fire a new EventDispatcher. The hook fires from ImageViewerRootView.didDisappear, i.e. AFTER the dismiss animation completes. A separate "onWillDismiss" event hooked into willDisappear could be added later if needed.

Android: register the event in the module manifest and declare an EventDispatcher field for type symmetry, but the actual fire site needs investigation of iielse/imageviewer's dismiss callback surface (likely an ImageViewerDialogFragment.onDismiss override or ImageViewerActionViewModel observation). Marked TODO; the JS prop is typed but never fires on Android in this commit.