### PR TITLE
fix: followup fixes to onLongPress

### DIFF
--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaModule.kt
@@ -43,6 +43,9 @@ class GaleriaModule : Module() {
             Prop("transitionOffsetX") { view: GaleriaView, transitionOffsetX: Int? ->
                 view.transitionOffsetX = transitionOffsetX
             }
+            Prop("longPressEnabled") { view: GaleriaView, longPressEnabled: Boolean ->
+                view.longPressEnabled = longPressEnabled
+            }
         }
     }
 }

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -8,7 +8,9 @@ import android.content.ContextWrapper
 import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.Keep
@@ -135,14 +137,11 @@ class GaleriaView(context: Context) : ViewGroup(context) {
 
                 }
                 if (longPressEnabled) {
-                    childView.setOnLongClickListener {
-                        onLongPress(emptyMap<String, Any>())
-                        true
-                    }
+                    installLongPressTouch(childView)
                 } else {
-                    childView.setOnLongClickListener(null)
-                    childView.isLongClickable = false
+                    childView.setOnTouchListener(null)
                 }
+                childView.isLongClickable = false
             } else if (childView is ViewGroup) {
                 setupImageViewer(childView)
             }
@@ -181,6 +180,71 @@ class GaleriaView(context: Context) : ViewGroup(context) {
 
     override fun onLayout(p0: Boolean, p1: Int, p2: Int, p3: Int, p4: Int) {
         setupImageViewer(this)
+    }
+
+    /**
+     * Wires a long-press detector on top of [childView] using a fixed 500 ms
+     * threshold (intentionally independent of the device's
+     * [ViewConfiguration.getLongPressTimeout]). This matches the iOS side,
+     * which uses [UILongPressGestureRecognizer] with `minimumPressDuration =
+     * 0.5`.
+     *
+     * On ACTION_DOWN we post a 500 ms Runnable; if it fires we emit the
+     * [onLongPress] event and remember that. On ACTION_UP we cancel the
+     * pending Runnable (a no-op if it already ran) and, if the long-press
+     * fired, swallow the UP event so [View.onTouchEvent] never observes the
+     * full down/up sequence — which is what suppresses the `setOnClickListener`
+     * fallback that otherwise opens the viewer. ACTION_MOVE that exceeds the
+     * touch slop, and ACTION_CANCEL, both cancel the pending Runnable.
+     *
+     * Returning `false` from DOWN/MOVE/non-suppressed UP keeps the existing
+     * click handling intact: the View still tracks the press and dispatches
+     * the click on UP via the normal flow.
+     */
+    private fun installLongPressTouch(childView: ImageView) {
+        val handler = Handler(Looper.getMainLooper())
+        val downPos = floatArrayOf(0f, 0f)
+        val touchSlop = ViewConfiguration.get(childView.context).scaledTouchSlop.toFloat()
+        var longPressFired = false
+
+        val longPressRunnable = Runnable {
+            longPressFired = true
+            onLongPress(emptyMap<String, Any>())
+        }
+
+        childView.setOnTouchListener { v, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    longPressFired = false
+                    downPos[0] = event.rawX
+                    downPos[1] = event.rawY
+                    handler.postDelayed(longPressRunnable, 500L)
+                    false
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val dx = event.rawX - downPos[0]
+                    val dy = event.rawY - downPos[1]
+                    if (dx * dx + dy * dy > touchSlop * touchSlop) {
+                        handler.removeCallbacks(longPressRunnable)
+                    }
+                    false
+                }
+                MotionEvent.ACTION_UP -> {
+                    handler.removeCallbacks(longPressRunnable)
+                    if (longPressFired) {
+                        v.isPressed = false
+                        true
+                    } else {
+                        false
+                    }
+                }
+                MotionEvent.ACTION_CANCEL -> {
+                    handler.removeCallbacks(longPressRunnable)
+                    false
+                }
+                else -> false
+            }
+        }
     }
 
 

--- a/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
+++ b/android/src/main/java/nandorojo/modules/galeria/GaleriaView.kt
@@ -58,6 +58,7 @@ class GaleriaView(context: Context) : ViewGroup(context) {
     var edgeToEdge = false
     var transitionOffsetY: Int? = null
     var transitionOffsetX: Int? = 0
+    var longPressEnabled: Boolean = false
     val viewModel: ImageViewerActionViewModel by lazy {
         ViewModelProvider(getViewModelOwner(context)).get(ImageViewerActionViewModel::class.java)
     }
@@ -133,9 +134,14 @@ class GaleriaView(context: Context) : ViewGroup(context) {
                     viewer.show()
 
                 }
-                childView.setOnLongClickListener {
-                    onLongPress(emptyMap<String, Any>())
-                    true
+                if (longPressEnabled) {
+                    childView.setOnLongClickListener {
+                        onLongPress(emptyMap<String, Any>())
+                        true
+                    }
+                } else {
+                    childView.setOnLongClickListener(null)
+                    childView.isLongClickable = false
                 }
             } else if (childView is ViewGroup) {
                 setupImageViewer(childView)

--- a/ios/GaleriaModule.swift
+++ b/ios/GaleriaModule.swift
@@ -39,6 +39,10 @@ public class GaleriaModule: Module {
         view.hidePageIndicators = hidePageIndicators ?? false
       }
 
+      Prop("longPressEnabled") { (view, longPressEnabled: Bool?) in
+        view.longPressEnabled = longPressEnabled ?? false
+      }
+
     }
   }
 

--- a/ios/GaleriaView.swift
+++ b/ios/GaleriaView.swift
@@ -52,6 +52,7 @@ class GaleriaView: ExpoView {
   var rightNavItemIconName: String?
   var hideBlurOverlay: Bool = false
   var hidePageIndicators: Bool = false
+  var longPressEnabled: Bool = false
   let onPressRightNavItemIcon = EventDispatcher()
   let onIndexChange = EventDispatcher()
   let onLongPress = EventDispatcher()
@@ -77,7 +78,9 @@ class GaleriaView: ExpoView {
       setupImageViewerWithSingleImage(childImage, viewerTheme: viewerTheme)
     }
 
-    attachLongPressRecognizer(to: childImage)
+    if longPressEnabled {
+      attachLongPressRecognizer(to: childImage)
+    }
   }
 
   private func attachLongPressRecognizer(to imageView: UIImageView) {

--- a/src/GaleriaView.android.tsx
+++ b/src/GaleriaView.android.tsx
@@ -17,6 +17,7 @@ const NativeImage = requireNativeView<
     urls?: string[]
     theme: 'dark' | 'light'
     onIndexChange?: (event: GaleriaIndexChangedEvent) => void
+    longPressEnabled?: boolean
   }
 >('Galeria')
 
@@ -72,6 +73,7 @@ const Galeria = Object.assign(
             return Image.resolveAssetSource(url).uri
           })}
           {...props}
+          longPressEnabled={!!props.onLongPress}
         />
       )
     },

--- a/src/GaleriaView.ios.tsx
+++ b/src/GaleriaView.ios.tsx
@@ -14,6 +14,7 @@ const NativeImage = requireNativeView<
     onIndexChange?: (event: GaleriaIndexChangedEvent) => void
     hideBlurOverlay?: boolean
     hidePageIndicators?: boolean
+    longPressEnabled?: boolean
   }
 >('Galeria')
 
@@ -72,6 +73,7 @@ const Galeria = Object.assign(
           })}
           index={initialIndex}
           {...props}
+          longPressEnabled={!!props.onLongPress}
         />
       )
     },


### PR DESCRIPTION
This is a followup to #115 adding two minor fixes to ensure the press behavior is in line with RN's Pressable.

- Ensures that when onLongPress is NOT specified pressing for a longer period of time still triggers normal onPress
- Ensure that the long-press delay on Android is always 500ms, matching what RN does

The fixes here are minor but the code is not necessarily trivial on the Android side. Probably warrants a close look.