### PR TITLE
fix(ios): bump min deployment target to 16.4 for Expo SDK 56

### DIFF
--- a/ios/Galeria.podspec
+++ b/ios/Galeria.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '16.0'
+  s.platform       = :ios, '16.4'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/nandorojo/galeria' }
   s.static_framework = true


### PR DESCRIPTION
## Summary
- Bumps `ios/Galeria.podspec` minimum deployment target from `16.0` → `16.4`.
- `ExpoModulesCore` in Expo SDK 56 has a minimum deployment target of iOS 16.4, so building galeria against it fails `pod install` with:
  ```
  compiling for iOS 16.0, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4
  ```
- The 16.0 floor was already fictional on SDK 56 — `ExpoModulesCore` enforces 16.4 transitively. This just aligns the declared minimum with what the dependency already requires.

Fixes #122.

## Risk
- iOS 16.4 shipped March 2023; the bump is 0.4 within the same major release.
- Expo itself raised its iOS floor to 16.4 in SDK 56, so any consumer on a current SDK is already there.

## Test plan
- [x] Applied as a patch on an Expo SDK 56 app — `pod install` and iOS build succeed.
- [ ] CI on this PR.