### PR TITLE
fix: raise iOS deployment target to 16.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,13 @@ export const ExpoImage = () => (
 ### Requirements
 
 - **New Architecture (Fabric)** – Galeria v3.0+ requires the new architecture. This means Expo SDK 54+ or React Native 0.79+.
-- **iOS 16+**
+- **iOS 16.4+**
 
-For iOS 16+ deployment target:
+For iOS 16.4+ deployment target:
 - Bare RN: set it in `ios/Podfile`
 - Expo: set it via [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/build-properties/)
+
+Expo SDK 56 requires iOS 16.4+ for `ExpoModulesCore`.
 
 ```bash
 yarn add @nandorojo/galeria

--- a/ios/Galeria.podspec
+++ b/ios/Galeria.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '16.0'
+  s.platform       = :ios, '16.4'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/nandorojo/galeria' }
   s.static_framework = true


### PR DESCRIPTION
## Summary

Raises Galeria's iOS deployment target from 16.0 to 16.4.

Expo SDK 56's ExpoModulesCore requires iOS 16.4. When Galeria is compiled with its current podspec target of iOS 16.0, Swift can fail while importing ExpoModulesCore:

`compiling for iOS 16.0, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4`

## Changes

- Update ios/Galeria.podspec to require iOS 16.4
- Update README requirements to document the new minimum iOS version

## Testing

- yarn install --immutable
- yarn build
- npx tsc --noEmit
- Ruby check confirmed ios/Galeria.podspec declares iOS 16.